### PR TITLE
feat: add compatibility-first project explorer improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@
 - **项目切换**：点击项目名快速切换
 - **编译配置**：支持自定义编译参数
 
+### 4. 兼容性优先的工程树选项
+
+- `KeilAssistant.ProjectExplorer.RememberExpandedState`：记住工程树展开状态，默认 `false`
+- `KeilAssistant.ProjectExplorer.SortOrder`：根工程排序方式，可选 `legacy`、`name`、`path`，默认 `legacy`
+- `KeilAssistant.ProjectExplorer.AutoRevealCurrentFile`：自动在工程树中定位当前文件，默认 `false`
+
+### 5. 新增命令
+
+- `Refresh Keil Project`
+- `Clear Project Cache And Refresh`
+- `Reveal Current File In Keil Project`
+
 ## 问题反馈 💬
 
 如有问题或建议，请通过以下方式联系：

--- a/README_EN.md
+++ b/README_EN.md
@@ -91,6 +91,21 @@ Seamless collaboration with Copilot through Chat Tools:
 }
 ```
 
+3. Compatibility-first project explorer options:
+```json
+{
+    "KeilAssistant.ProjectExplorer.RememberExpandedState": false,
+    "KeilAssistant.ProjectExplorer.SortOrder": "legacy",
+    "KeilAssistant.ProjectExplorer.AutoRevealCurrentFile": false
+}
+```
+
+### Commands
+
+- `Refresh Keil Project`
+- `Clear Project Cache And Refresh`
+- `Reveal Current File In Keil Project`
+
 ## System Requirements 💻
 
 - Windows 7/8/10/11

--- a/docs/superpowers/plans/2026-03-24-compatible-issue-support.md
+++ b/docs/superpowers/plans/2026-03-24-compatible-issue-support.md
@@ -1,0 +1,527 @@
+# Compatible Issue Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add compatibility-first support for issues `#18`, `#22`, `#23`, `#24`, `#25`, and `#26` without changing existing default behavior for current users.
+
+**Architecture:** Extract pure helpers for C/C++ config merging, tree state management, and path diagnostics so they can be tested without the VS Code runtime. Wire the existing `ProjectExplorer` to a real `TreeView`, add opt-in settings and explicit commands, and keep defaults aligned with today's behavior.
+
+**Tech Stack:** TypeScript, VS Code extension API, Node.js built-ins, Mocha
+
+---
+
+### Task 1: Build a Reliable Unit Test Path
+
+**Files:**
+- Create: `src/test/cppProperties.test.ts`
+- Create: `src/test/pathValidation.test.ts`
+- Create: `src/test/treeState.test.ts`
+- Modify: `package.json`
+- Test: `src/test/cppProperties.test.ts`
+- Test: `src/test/pathValidation.test.ts`
+- Test: `src/test/treeState.test.ts`
+
+- [ ] **Step 1: Write the failing test for C/C++ config merge preservation**
+
+```ts
+import { strict as assert } from 'assert';
+import { mergeCppProperties } from '../project/cppProperties';
+
+describe('mergeCppProperties', () => {
+    it('preserves user-owned fields on the target configuration', () => {
+        const current = {
+            configurations: [
+                {
+                    name: 'Demo_Debug',
+                    compilerPath: 'C:/Keil_v5/ARM/ARMCLANG/bin/armclang.exe',
+                    includePath: ['legacy/include'],
+                    defines: ['OLD'],
+                    browse: { path: ['kept/by/user'] }
+                }
+            ],
+            version: 4
+        };
+
+        const merged = mergeCppProperties(current, 'Demo_Debug', ['new/include', '${default}'], ['NEW']);
+
+        assert.equal(merged.configurations[0].compilerPath, current.configurations[0].compilerPath);
+        assert.deepEqual(merged.configurations[0].browse, current.configurations[0].browse);
+        assert.deepEqual(merged.configurations[0].includePath, ['new/include', '${default}']);
+        assert.deepEqual(merged.configurations[0].defines, ['NEW']);
+    });
+});
+```
+
+- [ ] **Step 2: Write the failing test for path diagnostics**
+
+```ts
+import { strict as assert } from 'assert';
+import { validateExecutionPaths } from '../project/pathValidation';
+
+describe('validateExecutionPaths', () => {
+    it('reports the exact missing path kind', () => {
+        const result = validateExecutionPaths({
+            builderExe: 'C:/missing/Uv4Caller.exe',
+            uv4Path: 'C:/Keil_v5/UV4/UV4.exe',
+            projectFile: 'D:/fw/demo.uvprojx',
+            projectDir: 'D:/fw'
+        }, () => false);
+
+        assert.equal(result.ok, false);
+        assert.equal(result.errors[0].kind, 'builderExe');
+    });
+});
+```
+
+- [ ] **Step 3: Write the failing test for tree-state IDs and sorting**
+
+```ts
+import { strict as assert } from 'assert';
+import { buildTreeItemId, sortProjects } from '../projectExplorer/treeState';
+
+describe('treeState', () => {
+    it('builds stable IDs from project path and labels', () => {
+        assert.equal(
+            buildTreeItemId('group', {
+                projectPath: 'D:/fw/demo.uvprojx',
+                targetName: 'Debug',
+                groupName: 'Drivers'
+            }),
+            'group:d:/fw/demo.uvprojx:Debug:Drivers'
+        );
+    });
+
+    it('keeps legacy order when sort mode is legacy', () => {
+        const result = sortProjects(
+            [
+                { label: 'B', path: 'D:/b.uvprojx' },
+                { label: 'A', path: 'D:/a.uvprojx' }
+            ],
+            'legacy'
+        );
+
+        assert.deepEqual(result.map(item => item.label), ['B', 'A']);
+    });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `npm test -- --grep "mergeCppProperties|validateExecutionPaths|treeState"`
+
+Expected: FAIL with module-not-found or missing export errors because the helper modules and working test runner do not exist yet.
+
+- [ ] **Step 5: Replace the broken default test entry with a Mocha-based unit test command**
+
+```json
+{
+  "scripts": {
+    "pretest": "npm run lint && npm run compile",
+    "test": "npx mocha dist/test/**/*.test.js"
+  }
+}
+```
+
+- [ ] **Step 6: Run tests again to verify the failure is now from missing helpers, not from a broken runner**
+
+Run: `npm test -- --grep "mergeCppProperties|validateExecutionPaths|treeState"`
+
+Expected: FAIL with import/export errors for `../project/cppProperties`, `../project/pathValidation`, and `../projectExplorer/treeState`.
+
+- [ ] **Step 7: Commit the test harness setup**
+
+```bash
+git add package.json src/test/cppProperties.test.ts src/test/pathValidation.test.ts src/test/treeState.test.ts
+git commit -m "test: add unit test entry points for compatibility work"
+```
+
+### Task 2: Preserve User-Owned `c_cpp_properties.json` Fields
+
+**Files:**
+- Create: `src/project/cppProperties.ts`
+- Modify: `src/extension.ts`
+- Test: `src/test/cppProperties.test.ts`
+
+- [ ] **Step 1: Extend the failing merge test to cover legacy config-name migration**
+
+```ts
+it('migrates a legacy target-name config without dropping user fields', () => {
+    const current = {
+        configurations: [
+            {
+                name: 'Debug',
+                compilerPath: 'C:/Keil_v5/ARM/ARMCC/bin/armcc.exe',
+                forcedInclude: ['kept.h']
+            }
+        ],
+        version: 4
+    };
+
+    const merged = mergeCppProperties(current, 'Demo_Debug', ['inc', '${default}'], ['DEF'], 'Debug');
+
+    assert.equal(merged.configurations[0].name, 'Demo_Debug');
+    assert.deepEqual(merged.configurations[0].forcedInclude, ['kept.h']);
+});
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `npm test -- --grep "mergeCppProperties"`
+
+Expected: FAIL because `mergeCppProperties` is not implemented.
+
+- [ ] **Step 3: Implement the minimal pure merge helper**
+
+```ts
+export function mergeCppProperties(
+    current: any,
+    configName: string,
+    includePath: string[],
+    defines: string[],
+    legacyName?: string
+) {
+    const root = current && typeof current === 'object' ? { ...current } : { version: 4 };
+    const configurations = Array.isArray(root.configurations) ? [...root.configurations] : [];
+
+    let index = configurations.findIndex(conf => conf?.name === configName);
+    const legacyIndex = legacyName ? configurations.findIndex(conf => conf?.name === legacyName) : -1;
+
+    if (index === -1 && legacyIndex !== -1) {
+        index = legacyIndex;
+    }
+
+    const next = index === -1 ? { name: configName } : { ...configurations[index], name: configName };
+    next.includePath = includePath;
+    next.defines = defines;
+
+    if (index === -1) {
+        configurations.push(next);
+    } else {
+        configurations[index] = next;
+    }
+
+    root.configurations = configurations;
+    root.version = root.version || 4;
+    return root;
+}
+```
+
+- [ ] **Step 4: Wire `Target.updateCppProperties()` to use the helper instead of mutating JSON inline**
+
+```ts
+const merged = mergeCppProperties(
+    obj,
+    this.cppConfigName,
+    Array.from(this.includes).concat(['${default}']),
+    Array.from(this.defines),
+    this.targetName
+);
+
+proFile.Write(JSON.stringify(merged, undefined, 4));
+```
+
+- [ ] **Step 5: Run the targeted test to verify it passes**
+
+Run: `npm test -- --grep "mergeCppProperties"`
+
+Expected: PASS
+
+- [ ] **Step 6: Run a compile-only regression check**
+
+Run: `npm run compile`
+
+Expected: PASS
+
+- [ ] **Step 7: Commit the merge-preservation change**
+
+```bash
+git add src/project/cppProperties.ts src/extension.ts src/test/cppProperties.test.ts
+git commit -m "fix: preserve user-owned cpp properties fields"
+```
+
+### Task 3: Add Path Diagnostics and Safe Refresh Commands
+
+**Files:**
+- Create: `src/project/pathValidation.ts`
+- Modify: `src/extension.ts`
+- Modify: `package.json`
+- Test: `src/test/pathValidation.test.ts`
+
+- [ ] **Step 1: Extend the failing path-validation test to cover missing project directory and missing UV4**
+
+```ts
+it('reports missing project directory before task execution', () => {
+    const result = validateExecutionPaths({
+        builderExe: 'C:/tools/Uv4Caller.exe',
+        uv4Path: 'C:/Keil_v5/UV4/UV4.exe',
+        projectFile: 'D:/fw/demo.uvprojx',
+        projectDir: 'D:/fw'
+    }, candidate => candidate !== 'D:/fw');
+
+    assert.equal(result.ok, false);
+    assert.equal(result.errors[0].kind, 'projectDir');
+});
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `npm test -- --grep "validateExecutionPaths"`
+
+Expected: FAIL because `validateExecutionPaths` is not implemented.
+
+- [ ] **Step 3: Implement the pure path validation helper**
+
+```ts
+export function validateExecutionPaths(
+    input: {
+        builderExe: string;
+        uv4Path: string;
+        projectFile: string;
+        projectDir: string;
+    },
+    exists: (path: string) => boolean
+) {
+    const errors = [];
+
+    if (!exists(input.builderExe)) errors.push({ kind: 'builderExe', path: input.builderExe });
+    if (!exists(input.uv4Path)) errors.push({ kind: 'uv4Path', path: input.uv4Path });
+    if (!exists(input.projectFile)) errors.push({ kind: 'projectFile', path: input.projectFile });
+    if (!exists(input.projectDir)) errors.push({ kind: 'projectDir', path: input.projectDir });
+
+    return { ok: errors.length === 0, errors };
+}
+```
+
+- [ ] **Step 4: Register explicit commands for refresh and cache-clear refresh**
+
+```json
+{
+  "contributes": {
+    "commands": [
+      { "command": "project.refresh", "title": "Refresh Keil Project" },
+      { "command": "project.clearCacheAndRefresh", "title": "Clear Project Cache And Refresh" },
+      { "command": "project.revealCurrentFile", "title": "Reveal Current File In Keil Project" }
+    ]
+  }
+}
+```
+
+Keep these commands Command Palette-only in this round. Do not add new persistent `view/title` buttons or context-menu entries unless a later pass proves they do not change the default explorer experience.
+
+- [ ] **Step 5: Call path validation before open/build/rebuild/download and surface a precise error**
+
+```ts
+const validation = validateExecutionPaths(input, candidate => fs.existsSync(candidate));
+if (!validation.ok) {
+    showMessage(formatPathValidationErrors(validation.errors), 'error', 4000);
+    return;
+}
+```
+
+- [ ] **Step 6: Implement `project.refresh` and `project.clearCacheAndRefresh` as explicit, safe commands**
+
+```ts
+subscriber.push(vscode.commands.registerCommand('project.refresh', () => prjExplorer.refreshActiveProject(false)));
+subscriber.push(vscode.commands.registerCommand('project.clearCacheAndRefresh', () => prjExplorer.refreshActiveProject(true)));
+```
+
+- [ ] **Step 7: Run the targeted test to verify it passes**
+
+Run: `npm test -- --grep "validateExecutionPaths"`
+
+Expected: PASS
+
+- [ ] **Step 8: Run compile and lint**
+
+Run: `npm run lint`
+Expected: PASS
+
+Run: `npm run compile`
+Expected: PASS
+
+- [ ] **Step 9: Commit the diagnostics and refresh work**
+
+```bash
+git add package.json src/project/pathValidation.ts src/extension.ts src/test/pathValidation.test.ts
+git commit -m "feat: add path diagnostics and safe project refresh commands"
+```
+
+### Task 4: Add Opt-In Tree State, Sorting, and Current-File Reveal
+
+**Files:**
+- Create: `src/projectExplorer/treeState.ts`
+- Modify: `src/extension.ts`
+- Modify: `package.json`
+- Test: `src/test/treeState.test.ts`
+
+- [ ] **Step 1: Extend the failing tree-state tests to cover name/path sorting and file-to-node matching**
+
+```ts
+it('sorts by normalized path when requested', () => {
+    const result = sortProjects(
+        [
+            { label: 'Demo', path: 'D:/z/demo.uvprojx' },
+            { label: 'Demo', path: 'D:/a/demo.uvprojx' }
+        ],
+        'path'
+    );
+
+    assert.deepEqual(result.map(item => item.path), ['D:/a/demo.uvprojx', 'D:/z/demo.uvprojx']);
+});
+
+it('finds the visible tree path for a current file', () => {
+    const match = findRevealPath('D:/fw/Core/Src/main.c', [
+        {
+            projectPath: 'D:/fw/demo.uvprojx',
+            targetName: 'Debug',
+            groupName: 'Core',
+            filePath: 'D:/fw/Core/Src/main.c'
+        }
+    ]);
+
+    assert.equal(match?.groupName, 'Core');
+});
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run: `npm test -- --grep "treeState"`
+
+Expected: FAIL because the helper module is not implemented.
+
+- [ ] **Step 3: Implement pure helpers for stable IDs, sort modes, and reveal matching**
+
+```ts
+export function buildTreeItemId(kind: string, input: Record<string, string>) {
+    const normalize = (value: string) => value.replace(/\\\\/g, '/').toLowerCase();
+    return [kind, ...Object.values(input).map(normalize)].join(':');
+}
+
+export function sortProjects<T extends { label: string; path: string }>(items: T[], mode: 'legacy' | 'name' | 'path') {
+    if (mode === 'legacy') return items;
+    return [...items].sort((a, b) => {
+        const keyA = mode === 'name' ? a.label : a.path;
+        const keyB = mode === 'name' ? b.label : b.path;
+        return keyA.localeCompare(keyB, undefined, { sensitivity: 'base' });
+    });
+}
+```
+
+- [ ] **Step 4: Add opt-in settings with compatibility-safe defaults**
+
+```json
+{
+  "KeilAssistant.ProjectExplorer.RememberExpandedState": {
+    "type": "boolean",
+    "default": false
+  },
+  "KeilAssistant.ProjectExplorer.SortOrder": {
+    "type": "string",
+    "enum": ["legacy", "name", "path"],
+    "default": "legacy"
+  },
+  "KeilAssistant.ProjectExplorer.AutoRevealCurrentFile": {
+    "type": "boolean",
+    "default": false
+  }
+}
+```
+
+- [ ] **Step 5: Upgrade `ProjectExplorer` to keep a `TreeView<IView>` instance and assign stable `TreeItem.id` values**
+
+```ts
+this.treeView = vscode.window.createTreeView('project', { treeDataProvider: this });
+context.subscriptions.push(this.treeView);
+
+res.id = buildTreeItemId(...);
+```
+
+- [ ] **Step 6: Persist expanded state only when the setting is enabled, and restore it after refresh**
+
+```ts
+this.treeView.onDidExpandElement(event => this.onExpandStateChanged(event.element, true));
+this.treeView.onDidCollapseElement(event => this.onExpandStateChanged(event.element, false));
+```
+
+- [ ] **Step 7: Implement the explicit `project.revealCurrentFile` command and optional auto-reveal setting**
+
+```ts
+subscriber.push(vscode.commands.registerCommand('project.revealCurrentFile', () => prjExplorer.revealCurrentEditor()));
+```
+
+- [ ] **Step 8: Run the targeted test to verify it passes**
+
+Run: `npm test -- --grep "treeState"`
+
+Expected: PASS
+
+- [ ] **Step 9: Run compile and lint**
+
+Run: `npm run lint`
+Expected: PASS
+
+Run: `npm run compile`
+Expected: PASS
+
+- [ ] **Step 10: Commit the tree-state work**
+
+```bash
+git add package.json src/projectExplorer/treeState.ts src/extension.ts src/test/treeState.test.ts
+git commit -m "feat: add opt-in tree state and reveal support"
+```
+
+### Task 5: Run No-Regression Verification and Update User Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README_EN.md`
+- Test: `src/test/cppProperties.test.ts`
+- Test: `src/test/pathValidation.test.ts`
+- Test: `src/test/treeState.test.ts`
+
+- [ ] **Step 1: Add concise documentation for the new commands and opt-in settings**
+
+```md
+### Compatibility-first project explorer options
+
+- `KeilAssistant.ProjectExplorer.RememberExpandedState` (default: `false`)
+- `KeilAssistant.ProjectExplorer.SortOrder` (default: `legacy`)
+- `KeilAssistant.ProjectExplorer.AutoRevealCurrentFile` (default: `false`)
+
+Commands:
+- `Refresh Keil Project`
+- `Clear Project Cache And Refresh`
+- `Reveal Current File In Keil Project`
+```
+
+- [ ] **Step 2: Run the full automated verification**
+
+Run: `npm test`
+
+Expected: PASS
+
+Run: `npm run lint`
+
+Expected: PASS
+
+Run: `npm run compile`
+
+Expected: PASS
+
+- [ ] **Step 3: Perform manual no-regression checks in VS Code**
+
+Run through this checklist:
+
+- Open a workspace with one `.uvprojx` and confirm auto-load still works.
+- Open a workspace with multiple projects and confirm default order matches current `legacy` behavior.
+- Build, rebuild, and download from the status bar without enabling any new setting.
+- Click a source node and confirm file opening behavior is unchanged.
+- Enable `RememberExpandedState`, expand groups, reload window, and confirm only then does state restore.
+- Run `Reveal Current File In Keil Project` and confirm explicit reveal works without affecting normal open flow.
+
+- [ ] **Step 4: Commit the verification and docs update**
+
+```bash
+git add README.md README_EN.md
+git commit -m "docs: describe compatibility-first project explorer options"
+```

--- a/docs/superpowers/specs/2026-03-24-compatible-issue-support-design.md
+++ b/docs/superpowers/specs/2026-03-24-compatible-issue-support-design.md
@@ -1,0 +1,307 @@
+# Compatible Issue Support Design
+
+## 背景
+
+当前仓库有一组开放 issue 指向两类问题：
+
+1. 现有行为对用户自定义内容不够友好，例如 `c_cpp_properties.json` 被插件反复覆盖。
+2. 工程树交互、刷新与错误提示还不够稳妥，例如展开状态、工程排序、文件定位、缓存刷新、路径报错定位不清。
+
+这轮工作的边界已经确认：
+
+- 支持 `#18`、`#22`、`#23`、`#24`、`#25`、`#26`
+- 不支持 `.uvproj/.uvprojx` 写回，因此不做真正的 `add file` / 修改 `include path`
+- 不支持断点、变量监控、调试器接入
+
+## 目标
+
+- 在不破坏老用户默认体验的前提下，补齐中小改动范围内可稳定落地的需求
+- 默认行为保持和当前版本一致，新增能力通过“更保守的内部实现”或“显式命令 / 显式设置”提供
+- 通过可测试的纯函数辅助模块，把高风险逻辑从 [src/extension.ts](/mnt/f/work_directory/Project/github/vscode_tools/keil-assistant/src/extension.ts) 中拆出来，降低回归风险
+
+## 非目标
+
+- 不重构整个扩展架构
+- 不改变现有 build / rebuild / download / open project 的默认交互
+- 不改变 target、group、source 的默认展示顺序
+- 不引入必须开启的新 UI 模式
+
+## 兼容性护栏
+
+### 1. 默认体验不变
+
+- `KeilAssistant.ProjectExplorer.RememberExpandedState` 默认 `false`
+- `KeilAssistant.ProjectExplorer.SortOrder` 默认 `legacy`
+- `KeilAssistant.ProjectExplorer.AutoRevealCurrentFile` 默认 `false`
+- 不修改已有命令名
+- 不修改已有 view id：仍然使用 `project`
+- 新增命令默认通过 Command Palette 提供，不增加常驻视图按钮
+
+### 2. 新能力失败时只降级，不阻塞主流程
+
+- 展开状态恢复失败：仅记录日志并跳过恢复
+- 当前文件定位失败：仅提示未找到，不影响文件打开
+- 路径预检失败：给出更明确的错误信息，阻止进入注定失败的执行路径
+- 缓存清理失败：只清理插件自有目录，不继续扩大删除范围
+
+### 3. 新能力只在批准范围内改变行为
+
+- `#18` 属于“减少覆盖”的修复，默认启用
+- `#22`、`#23`、`#24` 的自动化部分均为显式设置或显式命令，不影响老用户默认体验
+- `#25` 通过新增刷新命令解决，不偷偷清缓存
+
+## 设计总览
+
+本轮不重写工程解析主链路，只增加三类薄辅助层：
+
+1. `c_cpp_properties.json` 合并层
+2. 工程树状态层
+3. 路径诊断与安全刷新层
+
+所有新增逻辑优先抽为纯函数模块，`ProjectExplorer` 和 `Target` 仅负责调用与 VS Code API 对接。
+
+## 模块设计
+
+### A. `c_cpp_properties.json` 合并层
+
+新增建议模块：
+
+- `src/project/cppProperties.ts`
+
+职责：
+
+- 接收当前文件内容、目标配置名、插件生成的 `includePath` / `defines`
+- 只更新插件自己的配置项
+- 保留用户已存在的无关配置项和无关字段，例如 `compilerPath`、`browse`、`forcedInclude`
+- 兼容旧配置名迁移逻辑，即从旧 `targetName` 迁移到新的 `cppConfigName`
+
+当前风险点在 [src/extension.ts:795](/mnt/f/work_directory/Project/github/vscode_tools/keil-assistant/src/extension.ts#L795)：
+
+- 直接重写 `includePath`
+- 直接重写 `defines`
+- 读取失败时用默认模板重建，容易吞掉用户原有结构
+
+目标行为：
+
+- 仅在插件目标配置内覆盖 `includePath` 和 `defines`
+- 对用户已有字段采用保留策略
+- 如果 JSON 损坏，先回退到最小可用结构，但不碰其他配置文件
+
+### B. 工程树状态层
+
+新增建议模块：
+
+- `src/projectExplorer/treeState.ts`
+
+职责：
+
+- 计算稳定节点 ID
+- 根工程列表按配置排序
+- 记录 / 恢复展开状态
+- 从当前活动文件路径反查对应树节点路径
+
+为了拿到 `onDidExpandElement`、`onDidCollapseElement` 和 `reveal(...)` 能力，[src/extension.ts:1920](/mnt/f/work_directory/Project/github/vscode_tools/keil-assistant/src/extension.ts#L1920) 附近的注册方式将从单纯 `registerTreeDataProvider` 升级为“provider + `TreeView` 实例”。
+
+这不是 UI 重构，只是对现有树加可观测与可定位能力。
+
+稳定节点键建议：
+
+- `project:<normalized-project-path>`
+- `target:<normalized-project-path>:<target-name>`
+- `group:<normalized-project-path>:<target-name>:<group-name>`
+- `source:<normalized-project-path>:<target-name>:<normalized-file-path>`
+
+说明：
+
+- `Source` 节点 ID 主要用于 reveal 和稳定刷新
+- 展开状态只记录可折叠节点，即 project / target / group
+
+### C. 路径诊断与安全刷新层
+
+新增建议模块：
+
+- `src/project/pathValidation.ts`
+
+职责：
+
+- 在 open / build / rebuild / download 之前做统一预检
+- 输出结构化错误，指明缺失的是 `UV4.exe`、工程文件、工作目录还是插件 builder
+
+新增显式命令：
+
+- `project.refresh`
+- `project.clearCacheAndRefresh`
+- `project.revealCurrentFile`
+
+命令策略：
+
+- `project.refresh`：关闭并重新打开当前工程，保留当前工作区和用户文件
+- `project.clearCacheAndRefresh`：只清理 `globalStorageUri/<project-id>` 目录，再重新打开工程
+- `project.revealCurrentFile`：根据当前活动编辑器路径在 Keil 工程树中定位；必要时可切换到包含该文件的 target，但只在显式命令触发时执行
+
+## 需求映射
+
+### `#18` 误报错误 / `c_cpp_properties.json` 覆盖
+
+落地方式：
+
+- 抽离 merge helper
+- 保留用户已有字段
+- 只更新插件自己的目标配置
+- 对 `defines` 维持插件控制，避免旧行为失效
+
+兼容性说明：
+
+- 自动生成和自动选择配置行为不变
+- 只是减少不必要覆盖
+
+### `#22` 记住展开状态
+
+落地方式：
+
+- 增加设置 `KeilAssistant.ProjectExplorer.RememberExpandedState`
+- 关闭时完全保持当前行为
+- 开启后记录 project / target / group 的展开状态并在刷新后恢复
+
+兼容性说明：
+
+- 默认关闭，因此老用户完全无感
+
+### `#23` 工程排序
+
+落地方式：
+
+- 增加设置 `KeilAssistant.ProjectExplorer.SortOrder`
+- 选项：`legacy`、`name`、`path`
+- 只对根工程列表生效
+
+兼容性说明：
+
+- 默认 `legacy`，保持当前顺序
+
+### `#24` 当前文件定位到工程树
+
+落地方式：
+
+- 增加命令 `project.revealCurrentFile`
+- 可选设置 `KeilAssistant.ProjectExplorer.AutoRevealCurrentFile`
+- 自动定位默认关闭
+
+兼容性说明：
+
+- 默认不会额外切换 target、不会额外展开树
+
+### `#25` 缓存导致项目加载失败
+
+落地方式：
+
+- 增加显式刷新命令
+- 增加显式清理插件缓存并刷新命令
+- 强化工程文件变化后的 reload 路径，让 reload 失败后仍可人工触发恢复
+
+兼容性说明：
+
+- 默认不新增自动清理动作
+- 不删除工作区源文件和用户自定义配置
+
+### `#26` 系统找不到指定的路径
+
+落地方式：
+
+- 在 open 与任务执行前统一做路径预检
+- 错误文案明确指出缺失路径、当前配置项和建议修复动作
+
+兼容性说明：
+
+- 只把“晚失败”改成“早失败且更清楚”，不改已有成功路径
+
+## 数据流
+
+### `c_cpp_properties.json`
+
+1. `Target.load()` 继续解析 include 与 define
+2. `Target.updateCppProperties()` 改为调用 merge helper
+3. helper 返回合并后的 JSON 对象
+4. 插件写回 `.vscode/c_cpp_properties.json`
+5. `applyCppConfigurationSelection()` 继续调用 `C_Cpp.ConfigurationSelect`
+
+### 工程树状态
+
+1. `ProjectExplorer` 初始化时创建 `TreeView<IView>`
+2. 监听 expand / collapse 并在设置开启时写入 `workspaceState`
+3. `getTreeItem()` 为每个节点分配稳定 `id`
+4. `updateView()` 后根据设置恢复展开状态
+5. 显式 reveal 命令通过路径匹配定位节点并调用 `treeView.reveal`
+
+### 刷新与缓存清理
+
+1. 刷新命令读取当前 active project 与 active target
+2. 安全关闭项目
+3. 可选删除 `projectStorageDir`
+4. 重新创建 `KeilProject`
+5. 恢复 active target 并刷新视图
+
+## 风险与缓解
+
+### 风险 1：树节点刷新后 ID 不稳定，导致展开状态错乱
+
+缓解：
+
+- 使用基于项目路径、target 名、group 名、文件路径的稳定键
+- 排序逻辑与 ID 逻辑分离
+
+### 风险 2：reveal 当前文件时切到错误 target
+
+缓解：
+
+- 先在当前 active target 内查找
+- 未找到时再在其他 target 中查找
+- 仅在显式命令或显式开启设置时允许切 target
+
+### 风险 3：路径预检覆盖不全，仍然留下“系统找不到指定的路径”
+
+缓解：
+
+- 预检至少覆盖 `UV4.exe`、builder、工程文件、工程目录
+- 对日志写入路径失败保留原始异常文本
+
+### 风险 4：合并逻辑误伤用户配置
+
+缓解：
+
+- 为 merge helper 增加纯单元测试
+- 严格限制更新范围到插件目标配置的 `includePath` 与 `defines`
+
+## 测试策略
+
+### 自动测试
+
+新增基于 Mocha 的纯单元测试：
+
+- `src/test/cppProperties.test.ts`
+- `src/test/treeState.test.ts`
+- `src/test/pathValidation.test.ts`
+
+测试重点：
+
+- 配置合并保留用户字段
+- 稳定 ID 与排序策略
+- 当前文件路径到树路径的匹配
+- 路径预检错误信息
+
+### 手工回归
+
+- 单工程自动加载
+- 多工程自动加载
+- 切换 target
+- build / rebuild / download
+- 点击源文件打开
+- 关闭所有新设置时体验保持原状
+
+## 实施顺序
+
+1. 先修 `c_cpp_properties.json` 合并逻辑与测试基建
+2. 再补路径预检与刷新命令
+3. 最后接入 `TreeView`、展开状态、排序与 reveal
+
+这个顺序可以先解决稳定性问题，再补交互增强，并把回归面控制在最小范围内。

--- a/package.json
+++ b/package.json
@@ -72,6 +72,29 @@
                         "scope": "resource",
                         "markdownDescription": "uVision project file locations",
                         "default": []
+                    },
+                    "KeilAssistant.ProjectExplorer.RememberExpandedState": {
+                        "type": "boolean",
+                        "scope": "window",
+                        "markdownDescription": "Remember expanded Keil project tree nodes between refreshes and reloads.",
+                        "default": false
+                    },
+                    "KeilAssistant.ProjectExplorer.SortOrder": {
+                        "type": "string",
+                        "scope": "window",
+                        "markdownDescription": "Sort order for root Keil projects in the explorer.",
+                        "enum": [
+                            "legacy",
+                            "name",
+                            "path"
+                        ],
+                        "default": "legacy"
+                    },
+                    "KeilAssistant.ProjectExplorer.AutoRevealCurrentFile": {
+                        "type": "boolean",
+                        "scope": "window",
+                        "markdownDescription": "Automatically reveal the current file in the Keil project tree when possible.",
+                        "default": false
                     }
                 }
             }
@@ -136,6 +159,18 @@
                     "light": "./res/icons/CopyToClipboard_16x.svg",
                     "dark": "./res/icons/CopyToClipboard_16x.svg"
                 }
+            },
+            {
+                "command": "project.refresh",
+                "title": "Refresh Keil Project"
+            },
+            {
+                "command": "project.clearCacheAndRefresh",
+                "title": "Clear Project Cache And Refresh"
+            },
+            {
+                "command": "project.revealCurrentFile",
+                "title": "Reveal Current File In Keil Project"
             }
         ],
         "menus": {
@@ -334,7 +369,7 @@
         "webpack:watch": "npx webpack --mode development --watch",
         "lint": "npx eslint src --ext .ts",
         "pretest": "npm run lint && npm run compile",
-        "test": "node ./out/test/runTest.js"
+        "test": "node ./scripts/run-mocha.js"
     },
     "devDependencies": {
         "@types/glob": "^7.1.1",

--- a/scripts/run-mocha.js
+++ b/scripts/run-mocha.js
@@ -1,0 +1,21 @@
+const glob = require('glob');
+const Mocha = require('mocha');
+
+function getArgValue(flag) {
+    const index = process.argv.indexOf(flag);
+    if (index === -1 || index + 1 >= process.argv.length) {
+        return undefined;
+    }
+    return process.argv[index + 1];
+}
+
+const mocha = new Mocha({
+    grep: getArgValue('--grep')
+});
+
+const files = glob.sync('dist/**/*.test.js').sort();
+files.forEach(file => mocha.addFile(file));
+
+mocha.run(failures => {
+    process.exitCode = failures ? 1 : 0;
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,9 @@ import { FileWatcher } from '../lib/node_utility/FileWatcher';
 import { Time } from '../lib/node_utility/Time';
 import { isArray } from 'util';
 import { CmdLineHandler } from './CmdLineHandler';
+import { mergeCppProperties } from './project/cppProperties';
+import { formatPathValidationErrors, validateExecutionPaths } from './project/pathValidation';
+import { buildTreeItemId, findRevealPath, ProjectSortOrder, sortProjects } from './projectExplorer/treeState';
 
 // 添加一个消息防重复显示机制
 const messageDebouncer = new Map<string, number>();
@@ -182,30 +185,14 @@ export function activate(context: vscode.ExtensionContext) {
             // 根据工程类型检查对应的路径
             if (hasC51Project) {
                 const c51Path = vscode.workspace.getConfiguration('KeilAssistant.C51').get<string>('Uv4Path');
-                if (!c51Path) {
-                    showMessage(
-                        '请先设置 C51 UV4 路径！\n' +
-                        '1. 打开设置 (Ctrl+,)\n' +
-                        '2. 搜索 "KeilAssistant.C51.Uv4Path"\n' +
-                        '3. 设置 C51 UV4.exe 的绝对路径\n' +
-                        '示例路径：C:\\Keil_v5\\UV4\\UV4.exe',
-                        'error'
-                    );
+                if (!ensureUv4PathExists(c51Path || '', 'KeilAssistant.C51.Uv4Path', 'C51')) {
                     return;
                 }
             }
 
             if (hasArmProject) {
                 const mdkPath = vscode.workspace.getConfiguration('KeilAssistant.MDK').get<string>('Uv4Path');
-                if (!mdkPath) {
-                    showMessage(
-                        '请先设置 MDK UV4 路径！\n' +
-                        '1. 打开设置 (Ctrl+,)\n' +
-                        '2. 搜索 "KeilAssistant.MDK.Uv4Path"\n' +
-                        '3. 设置 MDK UV4.exe 的绝对路径\n' +
-                        '示例路径：C:\\Keil_v5\\UV4\\UV4.exe',
-                        'error'
-                    );
+                if (!ensureUv4PathExists(mdkPath || '', 'KeilAssistant.MDK.Uv4Path', 'MDK')) {
                     return;
                 }
             }
@@ -257,6 +244,12 @@ export function activate(context: vscode.ExtensionContext) {
     
     subscriber.push(vscode.commands.registerCommand('project.active', (item: IView) => prjExplorer.activeProject(item)));
 
+    subscriber.push(vscode.commands.registerCommand('project.refresh', () => prjExplorer.refreshActiveProject(false)));
+
+    subscriber.push(vscode.commands.registerCommand('project.clearCacheAndRefresh', () => prjExplorer.refreshActiveProject(true)));
+
+    subscriber.push(vscode.commands.registerCommand('project.revealCurrentFile', () => prjExplorer.revealCurrentEditor()));
+
     // 注册Chat Tools
     registerChatTools(context, prjExplorer);
 
@@ -277,6 +270,32 @@ function getMD5(data: string): string {
 
 function openWorkspace(wsFile: File) {
     vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.parse(wsFile.ToUri()));
+}
+
+function ensureUv4PathExists(path: string, settingKey: string, label: string): boolean {
+    if (!path) {
+        showMessage(
+            `请先设置 ${label} UV4 路径！\n` +
+            '1. 打开设置 (Ctrl+,)\n' +
+            `2. 搜索 "${settingKey}"\n` +
+            `3. 设置 ${label} UV4.exe 的绝对路径\n` +
+            '示例路径：C:\\Keil_v5\\UV4\\UV4.exe',
+            'error'
+        );
+        return false;
+    }
+
+    if (!fs.existsSync(path)) {
+        showMessage(
+            `${label} UV4.exe 路径不存在：${path}\n` +
+            `请检查设置项 "${settingKey}" 是否指向真实存在的 UV4.exe。`,
+            'error',
+            4000
+        );
+        return false;
+    }
+
+    return true;
 }
 
 //===============================
@@ -828,32 +847,15 @@ abstract class Target implements IView {
             obj = this.getDefCppProperties();
         }
 
-        let configList: any[] = Array.isArray(obj['configurations']) ? obj['configurations'] : [];
-        obj['configurations'] = configList;
+        const merged = mergeCppProperties(
+            obj,
+            this.cppConfigName,
+            Array.from(this.includes).concat(['${default}']),
+            Array.from(this.defines),
+            this.targetName
+        );
 
-        const legacyIndex = configList.findIndex((conf) => { return conf.name === this.targetName; });
-        let index = configList.findIndex((conf) => { return conf.name === this.cppConfigName; });
-
-        if (index === -1 && legacyIndex !== -1) {
-            index = legacyIndex;
-            configList[index]['name'] = this.cppConfigName; // migrate legacy name to avoid collisions
-        } else if (index !== -1 && legacyIndex !== -1 && legacyIndex !== index) {
-            configList.splice(legacyIndex, 1); // remove redundant legacy entry
-        }
-
-        if (index === -1) {
-            configList.push({
-                name: this.cppConfigName,
-                includePath: Array.from(this.includes).concat(['${default}']),
-                defines: Array.from(this.defines),
-                intelliSenseMode: '${default}'
-            });
-        } else {
-            configList[index]['includePath'] = Array.from(this.includes).concat(['${default}']);
-            configList[index]['defines'] = Array.from(this.defines);
-        }
-
-        proFile.Write(JSON.stringify(obj, undefined, 4));
+        proFile.Write(JSON.stringify(merged, undefined, 4));
     }
 
     public async applyCppConfigurationSelection(): Promise<void> {
@@ -988,6 +990,22 @@ abstract class Target implements IView {
 
         if (vscode.env.remoteName === 'wsl') {
             showMessage('Keil Assistant 检测到当前 VS Code 运行在 WSL 会话中，Keil/UV4 只能在 Windows 环境执行。请在 Windows 会话下打开工程或将终端切换到 PowerShell/CMD。', 'error', 4000);
+            return;
+        }
+
+        const uv4PathIndex = commands.findIndex(value => value === '--uv4Path');
+        const uv4Path = uv4PathIndex !== -1 ? commands[uv4PathIndex + 1] : '';
+        const validation = validateExecutionPaths({
+            builderExe: ResourceManager.getInstance().getBuilderExe(),
+            uv4Path,
+            projectFile: this.project.uvprjFile.path,
+            projectDir: this.project.uvprjFile.dir
+        }, candidate => fs.existsSync(candidate));
+
+        if (!validation.ok) {
+            const message = formatPathValidationErrors(validation.errors);
+            this.project.logger.log(`[ERROR] Task '${name}' path validation failed:\n${message}`);
+            showMessage(message, 'error', 4000);
             return;
         }
 
@@ -1899,6 +1917,7 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
     private ItemClickCommand = 'Item.Click';
     private readonly lastActiveProjectKey = 'keilAssistant.lastActiveProjectPath';
     private readonly closedProjectPathsKey = 'keilAssistant.closedProjectPaths';
+    private readonly expandedItemIdsKey = 'keilAssistant.projectExpandedItemIds';
 
     // Allow undefined/null for root refresh
     onDidChangeTreeData: vscode.Event<IView | undefined | null>;
@@ -1906,9 +1925,11 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
 
     private prjList: Map<string, KeilProject>;
     private currentActiveProject: KeilProject | undefined;
+    private treeView: vscode.TreeView<IView>;
     private buildStatusBarItem: vscode.StatusBarItem;
     private rebuildStatusBarItem: vscode.StatusBarItem;
     private downloadStatusBarItem: vscode.StatusBarItem;
+    private restoreExpandedStateTimer: NodeJS.Timeout | undefined;
 
     private extensionContext: vscode.ExtensionContext; // Store context
 
@@ -1917,8 +1938,20 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
         this.prjList = new Map();
         this.viewEvent = new vscode.EventEmitter<IView | undefined | null>();
         this.onDidChangeTreeData = this.viewEvent.event;
-        context.subscriptions.push(vscode.window.registerTreeDataProvider('project', this));
+        this.treeView = vscode.window.createTreeView('project', { treeDataProvider: this });
+        context.subscriptions.push(this.treeView);
         context.subscriptions.push(vscode.commands.registerCommand(this.ItemClickCommand, (item: IView) => this.onItemClick(item)));
+        context.subscriptions.push(this.treeView.onDidExpandElement(event => {
+            void this.onExpandedStateChanged(event.element, true);
+        }));
+        context.subscriptions.push(this.treeView.onDidCollapseElement(event => {
+            void this.onExpandedStateChanged(event.element, false);
+        }));
+        context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(() => {
+            if (this.shouldAutoRevealCurrentFile()) {
+                void this.revealCurrentEditor(false);
+            }
+        }));
 
         // 创建状态栏项
         this.buildStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -8);
@@ -1950,6 +1983,145 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
             this.buildStatusBarItem.hide();
             this.rebuildStatusBarItem.hide();
             this.downloadStatusBarItem.hide();
+        }
+    }
+
+    private getProjectExplorerConfig(): vscode.WorkspaceConfiguration {
+        return vscode.workspace.getConfiguration('KeilAssistant.ProjectExplorer');
+    }
+
+    private shouldRememberExpandedState(): boolean {
+        return this.getProjectExplorerConfig().get<boolean>('RememberExpandedState', false);
+    }
+
+    private shouldAutoRevealCurrentFile(): boolean {
+        return this.getProjectExplorerConfig().get<boolean>('AutoRevealCurrentFile', false);
+    }
+
+    private getProjectSortOrder(): ProjectSortOrder {
+        return this.getProjectExplorerConfig().get<ProjectSortOrder>('SortOrder', 'legacy');
+    }
+
+    private getExpandedItemIds(): string[] {
+        return this.extensionContext.workspaceState.get<string[]>(this.expandedItemIdsKey) || [];
+    }
+
+    private async setExpandedItemIds(ids: string[]): Promise<void> {
+        await this.extensionContext.workspaceState.update(this.expandedItemIdsKey, ids);
+    }
+
+    private canRememberExpandedState(element: IView): boolean {
+        return element instanceof KeilProject || element instanceof Target || element instanceof FileGroup;
+    }
+
+    private getElementId(element: IView): string | undefined {
+        const project = this.prjList.get(element.prjID);
+        if (!project) {
+            return undefined;
+        }
+
+        if (element instanceof KeilProject) {
+            return buildTreeItemId('project', {
+                projectPath: element.uvprjFile.path
+            });
+        }
+
+        if (element instanceof Target) {
+            return buildTreeItemId('target', {
+                projectPath: project.uvprjFile.path,
+                targetName: element.targetName
+            });
+        }
+
+        if (element instanceof FileGroup) {
+            return buildTreeItemId('group', {
+                projectPath: project.uvprjFile.path,
+                targetName: project.getActiveTarget()?.targetName || '',
+                groupName: element.label
+            });
+        }
+
+        if (element instanceof Source) {
+            return buildTreeItemId('source', {
+                projectPath: project.uvprjFile.path,
+                targetName: project.getActiveTarget()?.targetName || '',
+                filePath: element.file.path
+            });
+        }
+
+        return undefined;
+    }
+
+    private async onExpandedStateChanged(element: IView, expanded: boolean): Promise<void> {
+        if (!this.shouldRememberExpandedState() || !this.canRememberExpandedState(element)) {
+            return;
+        }
+
+        const elementId = this.getElementId(element);
+        if (!elementId) {
+            return;
+        }
+
+        const ids = new Set(this.getExpandedItemIds());
+        if (expanded) {
+            ids.add(elementId);
+        } else {
+            ids.delete(elementId);
+        }
+
+        await this.setExpandedItemIds(Array.from(ids));
+    }
+
+    private scheduleRestoreExpandedState(): void {
+        if (!this.shouldRememberExpandedState()) {
+            return;
+        }
+
+        if (this.restoreExpandedStateTimer) {
+            clearTimeout(this.restoreExpandedStateTimer);
+        }
+
+        this.restoreExpandedStateTimer = setTimeout(() => {
+            void this.restoreExpandedState();
+        }, 0);
+    }
+
+    private async restoreExpandedState(): Promise<void> {
+        if (!this.shouldRememberExpandedState()) {
+            return;
+        }
+
+        const expandedIds = new Set(this.getExpandedItemIds());
+        if (expandedIds.size === 0) {
+            return;
+        }
+
+        for (const project of this.prjList.values()) {
+            const projectId = this.getElementId(project);
+            if (projectId && expandedIds.has(projectId)) {
+                await this.treeView.reveal(project, { expand: true, focus: false, select: false });
+            }
+
+            const target = project.getActiveTarget();
+            if (!target) {
+                continue;
+            }
+
+            const targetId = this.getElementId(target);
+            if (targetId && expandedIds.has(targetId)) {
+                await this.treeView.reveal(target, { expand: true, focus: false, select: false });
+            }
+
+            for (const group of target.getChildViews() || []) {
+                if (!(group instanceof FileGroup)) {
+                    continue;
+                }
+
+                const groupId = this.getElementId(group);
+                if (groupId && expandedIds.has(groupId)) {
+                    await this.treeView.reveal(group, { expand: true, focus: false, select: false });
+                }
+            }
         }
     }
 
@@ -2094,6 +2266,15 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
     }
 
     async openProject(path: string, persistActive = true, removeClosed = true): Promise<KeilProject | undefined> {
+        if (!fs.existsSync(path)) {
+            throw new Error(`Keil 工程文件不存在: ${path}`);
+        }
+
+        const projectDir = node_path.dirname(path);
+        if (!fs.existsSync(projectDir)) {
+            throw new Error(`Keil 工程目录不存在: ${projectDir}`);
+        }
+
         // Pass extensionContext to KeilProject constructor
         const nPrj = new KeilProject(new File(path), this.extensionContext); 
         if (!this.prjList.has(nPrj.prjID)) {
@@ -2108,6 +2289,128 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
             return nPrj;
         }
         return undefined;
+    }
+
+    async refreshActiveProject(clearCache: boolean): Promise<void> {
+        const activeProject = this.currentActiveProject;
+        if (!activeProject) {
+            showMessage('当前没有活动工程可刷新。', 'warning');
+            return;
+        }
+
+        const projectPath = activeProject.uvprjFile.path;
+        const activeTargetName = activeProject.getActiveTarget()?.targetName;
+        const projectStoragePath = activeProject.projectStorageDir.path;
+
+        activeProject.deactive();
+        activeProject.close();
+        this.prjList.delete(activeProject.prjID);
+        this.currentActiveProject = undefined;
+        this.updateView();
+        this.updateStatusBarVisibility();
+
+        if (clearCache) {
+            try {
+                fs.rmSync(projectStoragePath, { recursive: true, force: true });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                showMessage(`清理项目缓存失败，将继续尝试重新加载工程：${message}`, 'warning', 4000);
+            }
+        }
+
+        try {
+            const reopened = await this.openProject(projectPath, true, false);
+            if (reopened && activeTargetName && reopened.getTargetByName(activeTargetName)) {
+                await reopened.setActiveTarget(activeTargetName);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            showMessage(`刷新工程失败！错误信息: ${message}`, 'error', 4000);
+        }
+    }
+
+    async revealCurrentEditor(showMissingMessage = true): Promise<void> {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.document.uri.scheme !== 'file') {
+            if (showMissingMessage) {
+                showMessage('当前没有可定位的文件。', 'warning');
+            }
+            return;
+        }
+
+        const match = findRevealPath(editor.document.uri.fsPath, this.getRevealEntries());
+        if (!match) {
+            if (showMissingMessage) {
+                showMessage('当前文件不在已加载的 Keil 工程树中。', 'warning');
+            }
+            return;
+        }
+
+        if (this.currentActiveProject?.prjID !== match.project.prjID) {
+            await this.setActiveProject(match.project, true);
+        }
+
+        if (match.project.getActiveTarget()?.targetName !== match.target.targetName) {
+            await match.project.setActiveTarget(match.target.targetName);
+            this.updateView();
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        const activeProject = this.prjList.get(match.project.prjID);
+        const target = activeProject?.getTargetByName(match.target.targetName);
+        const group = target?.getChildViews()?.find(view => view instanceof FileGroup && view.label === match.group.label) as FileGroup | undefined;
+        const source = group?.sources.find(item => node_path.normalize(item.file.path) === node_path.normalize(match.source.file.path));
+
+        if (!activeProject || !target || !group || !source) {
+            if (showMissingMessage) {
+                showMessage('当前文件定位失败，工程树节点未找到。', 'warning');
+            }
+            return;
+        }
+
+        await this.treeView.reveal(activeProject, { expand: true, focus: false, select: false });
+        await this.treeView.reveal(target, { expand: true, focus: false, select: false });
+        await this.treeView.reveal(group, { expand: true, focus: false, select: false });
+        await this.treeView.reveal(source, { expand: false, focus: false, select: true });
+    }
+
+    private getRevealEntries() {
+        const entries: Array<{
+            projectPath: string;
+            targetName: string;
+            groupName: string;
+            filePath: string;
+            project: KeilProject;
+            target: Target;
+            group: FileGroup;
+            source: Source;
+        }> = [];
+
+        for (const project of this.prjList.values()) {
+            for (const target of project.getTargets()) {
+                for (const groupView of target.getChildViews() || []) {
+                    if (!(groupView instanceof FileGroup)) {
+                        continue;
+                    }
+
+                    for (const source of groupView.sources) {
+                        entries.push({
+                            projectPath: project.uvprjFile.path,
+                            targetName: target.targetName,
+                            groupName: groupView.label,
+                            filePath: source.file.path,
+                            project,
+                            target,
+                            group: groupView,
+                            source
+                        });
+                    }
+                }
+            }
+        }
+
+        return entries;
     }
 
     async closeProject(pID: string) {
@@ -2176,6 +2479,7 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
 
     updateView() {
         this.viewEvent.fire(undefined); // Pass undefined as argument
+        this.scheduleRestoreExpandedState();
     }
 
     //----------------------------------
@@ -2218,11 +2522,13 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
     getTreeItem(element: IView): vscode.TreeItem | Thenable<vscode.TreeItem> {
 
         const res = new vscode.TreeItem(element.label);
+        const elementId = this.getElementId(element);
 
         res.contextValue = element.contextVal;
         res.tooltip = element.tooltip;
         res.collapsibleState = element.getChildViews() === undefined ?
             vscode.TreeItemCollapsibleState.None : vscode.TreeItemCollapsibleState.Collapsed;
+        res.id = elementId;
 
         if (element instanceof KeilProject && this.currentActiveProject?.prjID === element.prjID) {
             res.description = '*';
@@ -2258,7 +2564,14 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
 
     getChildren(element?: IView | undefined): vscode.ProviderResult<IView[]> {
         if (element === undefined) {
-            return Array.from(this.prjList.values());
+            return sortProjects(
+                Array.from(this.prjList.values()).map(project => ({
+                    label: project.label,
+                    path: project.uvprjFile.path,
+                    project
+                })),
+                this.getProjectSortOrder()
+            ).map(item => item.project);
         } else {
             return element.getChildViews();
         }
@@ -2275,6 +2588,10 @@ class ProjectExplorer implements vscode.TreeDataProvider<IView>, vscode.Disposab
     dispose() {
         // Dispose of any resources managed by ProjectExplorer itself, if any.
         // TreeDataProvider and Commands pushed to context.subscriptions are disposed by VSCode.
+        if (this.restoreExpandedStateTimer) {
+            clearTimeout(this.restoreExpandedStateTimer);
+        }
+        this.treeView.dispose();
         this.buildStatusBarItem.dispose();
         this.rebuildStatusBarItem.dispose();
         this.downloadStatusBarItem.dispose();

--- a/src/project/cppProperties.ts
+++ b/src/project/cppProperties.ts
@@ -1,0 +1,64 @@
+export interface CppConfiguration {
+    name: string;
+    includePath?: string[];
+    defines?: string[];
+    [key: string]: unknown;
+}
+
+export interface CppPropertiesRoot {
+    configurations: CppConfiguration[];
+    version: number;
+    [key: string]: unknown;
+}
+
+function normalizeRoot(current: unknown): CppPropertiesRoot {
+    const root = current && typeof current === 'object' ? { ...(current as Record<string, unknown>) } : {};
+    const configurations = Array.isArray(root.configurations) ? [...root.configurations as CppConfiguration[]] : [];
+
+    return {
+        ...root,
+        configurations,
+        version: typeof root.version === 'number' ? root.version : 4
+    };
+}
+
+export function mergeCppProperties(
+    current: unknown,
+    configName: string,
+    includePath: string[],
+    defines: string[],
+    legacyName?: string
+): CppPropertiesRoot {
+    const root = normalizeRoot(current);
+    const configurations = root.configurations;
+
+    let index = configurations.findIndex(conf => conf?.name === configName);
+    const legacyIndex = legacyName ? configurations.findIndex(conf => conf?.name === legacyName) : -1;
+
+    if (index === -1 && legacyIndex !== -1) {
+        index = legacyIndex;
+    } else if (index !== -1 && legacyIndex !== -1 && index !== legacyIndex) {
+        configurations.splice(legacyIndex, 1);
+        if (legacyIndex < index) {
+            index--;
+        }
+    }
+
+    const next: CppConfiguration = index === -1
+        ? { name: configName }
+        : { ...configurations[index], name: configName };
+
+    next.includePath = includePath;
+    next.defines = defines;
+
+    if (index === -1) {
+        configurations.push(next);
+    } else {
+        configurations[index] = next;
+    }
+
+    return {
+        ...root,
+        configurations
+    };
+}

--- a/src/project/pathValidation.ts
+++ b/src/project/pathValidation.ts
@@ -1,0 +1,54 @@
+export type ValidationPathKind = 'builderExe' | 'uv4Path' | 'projectFile' | 'projectDir';
+
+export interface ValidationError {
+    kind: ValidationPathKind;
+    path: string;
+}
+
+export interface ExecutionPathInput {
+    builderExe: string;
+    uv4Path: string;
+    projectFile: string;
+    projectDir: string;
+}
+
+export interface ValidationResult {
+    ok: boolean;
+    errors: ValidationError[];
+}
+
+export function validateExecutionPaths(
+    input: ExecutionPathInput,
+    exists: (path: string) => boolean
+): ValidationResult {
+    const errors: ValidationError[] = [];
+
+    if (!exists(input.builderExe)) {
+        errors.push({ kind: 'builderExe', path: input.builderExe });
+    }
+    if (!exists(input.uv4Path)) {
+        errors.push({ kind: 'uv4Path', path: input.uv4Path });
+    }
+    if (!exists(input.projectFile)) {
+        errors.push({ kind: 'projectFile', path: input.projectFile });
+    }
+    if (!exists(input.projectDir)) {
+        errors.push({ kind: 'projectDir', path: input.projectDir });
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors
+    };
+}
+
+export function formatPathValidationErrors(errors: ValidationError[]): string {
+    const labels: Record<ValidationPathKind, string> = {
+        builderExe: 'Uv4Caller.exe 路径不存在',
+        uv4Path: 'UV4.exe 路径不存在',
+        projectFile: 'Keil 工程文件不存在',
+        projectDir: 'Keil 工程目录不存在'
+    };
+
+    return errors.map(error => `${labels[error.kind]}: ${error.path}`).join('\n');
+}

--- a/src/projectExplorer/treeState.ts
+++ b/src/projectExplorer/treeState.ts
@@ -1,0 +1,45 @@
+export type ProjectSortOrder = 'legacy' | 'name' | 'path';
+
+export interface ProjectListItem {
+    label: string;
+    path: string;
+}
+
+export interface RevealEntry {
+    projectPath: string;
+    targetName: string;
+    groupName: string;
+    filePath: string;
+}
+
+function normalizeValue(value: string): string {
+    return value.replace(/\\/g, '/').toLowerCase();
+}
+
+export function buildTreeItemId(kind: string, input: Record<string, string>): string {
+    return [kind, ...Object.values(input).map(normalizeValue)].join(':');
+}
+
+export function sortProjects<T extends ProjectListItem>(items: T[], mode: ProjectSortOrder): T[] {
+    if (mode === 'legacy') {
+        return items;
+    }
+
+    return [...items].sort((left, right) => {
+        const primaryLeft = mode === 'name' ? left.label : left.path;
+        const primaryRight = mode === 'name' ? right.label : right.path;
+        const primary = primaryLeft.localeCompare(primaryRight, undefined, { sensitivity: 'base' });
+        if (primary !== 0) {
+            return primary;
+        }
+
+        const tieBreakLeft = mode === 'name' ? left.path : left.label;
+        const tieBreakRight = mode === 'name' ? right.path : right.label;
+        return tieBreakLeft.localeCompare(tieBreakRight, undefined, { sensitivity: 'base' });
+    });
+}
+
+export function findRevealPath<T extends RevealEntry>(currentFilePath: string, entries: T[]): T | undefined {
+    const normalizedCurrent = normalizeValue(currentFilePath);
+    return entries.find(entry => normalizeValue(entry.filePath) === normalizedCurrent);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
 		"strict": true,   /* enable all strict type-checking options */
 		"types": [
 			"node",
-			"vscode"
+			"vscode",
+			"mocha"
 		],
 		"typeRoots": [
 			"./node_modules/@types"


### PR DESCRIPTION
## Summary
- preserve user-owned `c_cpp_properties.json` fields while keeping plugin-managed include/define updates
- add compatibility-first project explorer settings and commands for refresh, cache refresh, sorting, expanded-state restore, and current-file reveal
- add path validation helpers, unit tests, and docs for the new behavior

## Compatibility Guardrails
- default settings keep existing behavior: `RememberExpandedState=false`, `SortOrder=legacy`, `AutoRevealCurrentFile=false`
- new commands are command-palette commands only in this round, with no new persistent explorer buttons
- refresh paths fail earlier with clearer messages instead of changing successful flows

## Test Plan
- [x] `npm test`
- [x] `npm run compile`
- [x] `npm run lint` (passes with pre-existing warnings only)
