### PR TITLE
feat: surface project explorer actions in the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ out
 out.min
 node_modules
 test
+!src/test/
+!src/test/*.test.ts
 *.vsix
 dist
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "keil-assistant-new" extension will be documented in 
   - `Refresh Keil Project`
   - `Clear Project Cache And Refresh`
   - `Reveal Current File In Keil Project`
+- 将常用工程树动作补充到工程树标题栏和项目右键菜单，减少只依赖命令面板的使用成本
 
 ### 修复问题 🔧
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 
 ### 4. 兼容性优先的工程树选项
 
+- 配置入口：`Ctrl+,` 打开 VS Code Settings，搜索 `KeilAssistant.ProjectExplorer`
 - `KeilAssistant.ProjectExplorer.RememberExpandedState`：记住工程树展开状态，默认 `false`
 - `KeilAssistant.ProjectExplorer.SortOrder`：根工程排序方式，可选 `legacy`、`name`、`path`，默认 `legacy`
 - `KeilAssistant.ProjectExplorer.AutoRevealCurrentFile`：自动在工程树中定位当前文件，默认 `false`
@@ -86,6 +87,10 @@
 - `Refresh Keil Project`
 - `Clear Project Cache And Refresh`
 - `Reveal Current File In Keil Project`
+- 使用入口：
+  - 工程树标题栏：`Refresh Keil Project`、`Reveal Current File In Keil Project`
+  - 工程树项目右键菜单：`Refresh Keil Project`、`Clear Project Cache And Refresh`、`Reveal Current File In Keil Project`
+  - 命令面板仍然保留以上 3 个命令，兼容老用户习惯
 
 ## 问题反馈 💬
 

--- a/package.json
+++ b/package.json
@@ -162,7 +162,11 @@
             },
             {
                 "command": "project.refresh",
-                "title": "Refresh Keil Project"
+                "title": "Refresh Keil Project",
+                "icon": {
+                    "light": "./res/icons/refresh-light.svg",
+                    "dark": "./res/icons/refresh-dark.svg"
+                }
             },
             {
                 "command": "project.clearCacheAndRefresh",
@@ -170,7 +174,11 @@
             },
             {
                 "command": "project.revealCurrentFile",
-                "title": "Reveal Current File In Keil Project"
+                "title": "Reveal Current File In Keil Project",
+                "icon": {
+                    "light": "./res/icons/ActiveApplication_16x.svg",
+                    "dark": "./res/icons/ActiveApplication_16x.svg"
+                }
             }
         ],
         "menus": {
@@ -178,6 +186,16 @@
                 {
                     "command": "explorer.open",
                     "group": "navigation",
+                    "when": "view == project"
+                },
+                {
+                    "command": "project.refresh",
+                    "group": "navigation@1",
+                    "when": "view == project"
+                },
+                {
+                    "command": "project.revealCurrentFile",
+                    "group": "navigation@2",
                     "when": "view == project"
                 }
             ],
@@ -188,6 +206,21 @@
                 },
                 {
                     "command": "project.active",
+                    "when": "viewItem == Project"
+                },
+                {
+                    "command": "project.refresh",
+                    "group": "navigation",
+                    "when": "viewItem == Project"
+                },
+                {
+                    "command": "project.clearCacheAndRefresh",
+                    "group": "navigation",
+                    "when": "viewItem == Project"
+                },
+                {
+                    "command": "project.revealCurrentFile",
+                    "group": "navigation",
                     "when": "viewItem == Project"
                 },
                 {

--- a/src/test/cppProperties.test.ts
+++ b/src/test/cppProperties.test.ts
@@ -1,0 +1,46 @@
+import { strict as assert } from 'assert';
+import { mergeCppProperties } from '../project/cppProperties';
+
+describe('mergeCppProperties', () => {
+    it('preserves user-owned fields on the target configuration', () => {
+        const current = {
+            configurations: [
+                {
+                    name: 'Demo_Debug',
+                    compilerPath: 'C:/Keil_v5/ARM/ARMCLANG/bin/armclang.exe',
+                    includePath: ['legacy/include'],
+                    defines: ['OLD'],
+                    browse: { path: ['kept/by/user'] }
+                }
+            ],
+            version: 4
+        };
+
+        const merged = mergeCppProperties(current, 'Demo_Debug', ['new/include', '${default}'], ['NEW']);
+
+        assert.equal(merged.configurations[0].compilerPath, current.configurations[0].compilerPath);
+        assert.deepEqual(merged.configurations[0].browse, current.configurations[0].browse);
+        assert.deepEqual(merged.configurations[0].includePath, ['new/include', '${default}']);
+        assert.deepEqual(merged.configurations[0].defines, ['NEW']);
+    });
+
+    it('migrates a legacy target-name config without dropping user fields', () => {
+        const current = {
+            configurations: [
+                {
+                    name: 'Debug',
+                    compilerPath: 'C:/Keil_v5/ARM/ARMCC/bin/armcc.exe',
+                    forcedInclude: ['kept.h']
+                }
+            ],
+            version: 4
+        };
+
+        const merged = mergeCppProperties(current, 'Demo_Debug', ['inc', '${default}'], ['DEF'], 'Debug');
+
+        assert.equal(merged.configurations[0].name, 'Demo_Debug');
+        assert.deepEqual(merged.configurations[0].forcedInclude, ['kept.h']);
+        assert.deepEqual(merged.configurations[0].includePath, ['inc', '${default}']);
+        assert.deepEqual(merged.configurations[0].defines, ['DEF']);
+    });
+});

--- a/src/test/packageContributions.test.ts
+++ b/src/test/packageContributions.test.ts
@@ -1,0 +1,48 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type MenuEntry = {
+    command: string;
+    when?: string;
+    group?: string;
+};
+
+function readPackageJson(): any {
+    const packageJsonPath = path.resolve(__dirname, '../../../package.json');
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+}
+
+function findMenuEntries(entries: MenuEntry[], command: string): MenuEntry[] {
+    return entries.filter(entry => entry.command === command);
+}
+
+describe('package contributions', () => {
+    it('exposes project refresh and reveal actions from the project explorer UI', () => {
+        const manifest = readPackageJson();
+        const menus = manifest.contributes?.menus ?? {};
+        const viewTitleEntries = menus['view/title'] as MenuEntry[] || [];
+        const viewItemContextEntries = menus['view/item/context'] as MenuEntry[] || [];
+
+        assert.ok(
+            findMenuEntries(viewTitleEntries, 'project.refresh').some(entry => entry.when === 'view == project'),
+            'expected project.refresh in the project view title'
+        );
+        assert.ok(
+            findMenuEntries(viewTitleEntries, 'project.revealCurrentFile').some(entry => entry.when === 'view == project'),
+            'expected project.revealCurrentFile in the project view title'
+        );
+        assert.ok(
+            findMenuEntries(viewItemContextEntries, 'project.refresh').some(entry => entry.when === 'viewItem == Project'),
+            'expected project.refresh in the project item context menu'
+        );
+        assert.ok(
+            findMenuEntries(viewItemContextEntries, 'project.clearCacheAndRefresh').some(entry => entry.when === 'viewItem == Project'),
+            'expected project.clearCacheAndRefresh in the project item context menu'
+        );
+        assert.ok(
+            findMenuEntries(viewItemContextEntries, 'project.revealCurrentFile').some(entry => entry.when === 'viewItem == Project'),
+            'expected project.revealCurrentFile in the project item context menu'
+        );
+    });
+});

--- a/src/test/pathValidation.test.ts
+++ b/src/test/pathValidation.test.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from 'assert';
+import { validateExecutionPaths } from '../project/pathValidation';
+
+describe('validateExecutionPaths', () => {
+    it('reports the exact missing path kind', () => {
+        const result = validateExecutionPaths({
+            builderExe: 'C:/missing/Uv4Caller.exe',
+            uv4Path: 'C:/Keil_v5/UV4/UV4.exe',
+            projectFile: 'D:/fw/demo.uvprojx',
+            projectDir: 'D:/fw'
+        }, () => false);
+
+        assert.equal(result.ok, false);
+        assert.equal(result.errors[0].kind, 'builderExe');
+    });
+
+    it('reports missing project directory before task execution', () => {
+        const result = validateExecutionPaths({
+            builderExe: 'C:/tools/Uv4Caller.exe',
+            uv4Path: 'C:/Keil_v5/UV4/UV4.exe',
+            projectFile: 'D:/fw/demo.uvprojx',
+            projectDir: 'D:/fw'
+        }, candidate => candidate !== 'D:/fw');
+
+        assert.equal(result.ok, false);
+        assert.equal(result.errors[0].kind, 'projectDir');
+    });
+});

--- a/src/test/treeState.test.ts
+++ b/src/test/treeState.test.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from 'assert';
+import { buildTreeItemId, findRevealPath, sortProjects } from '../projectExplorer/treeState';
+
+describe('treeState', () => {
+    it('builds stable IDs from project path and labels', () => {
+        assert.equal(
+            buildTreeItemId('group', {
+                projectPath: 'D:/fw/demo.uvprojx',
+                targetName: 'Debug',
+                groupName: 'Drivers'
+            }),
+            'group:d:/fw/demo.uvprojx:debug:drivers'
+        );
+    });
+
+    it('keeps legacy order when sort mode is legacy', () => {
+        const result = sortProjects(
+            [
+                { label: 'B', path: 'D:/b.uvprojx' },
+                { label: 'A', path: 'D:/a.uvprojx' }
+            ],
+            'legacy'
+        );
+
+        assert.deepEqual(result.map((item: { label: string }) => item.label), ['B', 'A']);
+    });
+
+    it('sorts by normalized path when requested', () => {
+        const result = sortProjects(
+            [
+                { label: 'Demo', path: 'D:/z/demo.uvprojx' },
+                { label: 'Demo', path: 'D:/a/demo.uvprojx' }
+            ],
+            'path'
+        );
+
+        assert.deepEqual(result.map((item: { path: string }) => item.path), ['D:/a/demo.uvprojx', 'D:/z/demo.uvprojx']);
+    });
+
+    it('finds the visible tree path for a current file', () => {
+        const match = findRevealPath('D:/fw/Core/Src/main.c', [
+            {
+                projectPath: 'D:/fw/demo.uvprojx',
+                targetName: 'Debug',
+                groupName: 'Core',
+                filePath: 'D:/fw/Core/Src/main.c'
+            }
+        ]);
+
+        assert.equal(match?.groupName, 'Core');
+    });
+});


### PR DESCRIPTION
## Summary
- add project explorer UI entry points for refresh and reveal actions
- add project-level context menu entry points for refresh, clear-cache refresh, and reveal
- update README and changelog, and commit the related project explorer regression tests

## Verification
- npm test

## Compatibility
- existing settings keys stay unchanged
- command palette entry points stay available
- version remains 2.5.0 as requested