### PR TITLE
chore: release 2.5.1 for marketplace re-publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "keil-assistant-new" extension will be documented in this file.
 
+## [2.5.1] - 2026-03-25
+
+### 优化改进 ✨
+
+- 调整扩展市场可见标识，明确声明这是原版 Keil Assistant 的社区维护分支
+- 更新扩展显示名、简介、设置分组标题与中英文 README 首页，降低与原扩展的混淆度
+- 替换为新的社区分支图标，同时保持扩展 ID 与 `KeilAssistant.*` 配置键不变，避免影响老用户升级路径
+
 ## [2.5.0] - 2026-03-24
 
 ### 新增功能 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "keil-assistant-new",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "keil-assistant-new",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "dependencies": {
                 "xml2js": "^0.6.2"
             },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "keil-assistant-new",
     "displayName": "Keil Assistant Community Fork",
     "description": "A community-maintained fork of the original Keil Assistant for VS Code",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "publisher": "candycium",
     "author": {
         "name": "Rui Wang"


### PR DESCRIPTION
## Summary
- bump the extension version to 2.5.1 after the marketplace differentiation changes
- sync the root version in package-lock.json
- add the 2026-03-25 changelog entry for the marketplace compliance re-publish

## Verification
- npm test

## Notes
- this release keeps the same extension ID and user settings path
- it exists so the marketplace package can be re-published with a new version number